### PR TITLE
Fix/revert the new strange behaviour of (end timed-task)

### DIFF
--- a/build.lisp
+++ b/build.lisp
@@ -95,8 +95,6 @@
 (defgeneric perform-build (build))
 
 (defun handle-build-start (build)
-  (setf (start build) (get-universal-time))
-  (setf (end build) T)
   (setf (status build) :running)
   (format *build-output* "~&;;;; Autobuild ~a" (status build))
   (format *build-output* "~&;;; Started on ~a (~a)~%" (format-date (start build)) (start build))

--- a/front.lisp
+++ b/front.lisp
@@ -163,7 +163,7 @@
      (end timed-task))
     (end-formatted
      (case (end timed-task)
-       ((NIL T) "-")
+       ((NIL) "-")
        (T (autobuild::format-date (end timed-task)))))
     (T (call-next-method))))
 

--- a/stage.lisp
+++ b/stage.lisp
@@ -12,15 +12,15 @@
 
 (defmethod run-task :around ((timed-task timed-task))
   (setf (start timed-task) (get-universal-time)
-        (end timed-task) T)
+        (end timed-task) nil)
   (unwind-protect
        (call-next-method)
     (setf (end timed-task) (get-universal-time))))
 
 (defgeneric duration (timed-task)
   (:method ((timed-task timed-task))
-    (when (and (start timed-task) (end timed-task))
-      (- (if (eql (end timed-task) T)
+    (when (start timed-task)
+      (- (if (null (end timed-task))
              (get-universal-time)
              (end timed-task))
          (start timed-task)))))


### PR DESCRIPTION
Until recently, `(end timed-task)` would be `NIL` when invalid (created/running); it was then changed to be `T`, which broke the JavaScript rendering of timestamps. I believe that `(end timed-task)` should return `NIL` when the task does not have an end-time, thus this change reverts the new behaviour.

``` diff
# STATE `(,(end timed-task))
-CREATED (nil) -> RUNNING (T)   -> DONE (universal-time)
+CREATED (nil) -> RUNNING (nil) -> DONE (universal-time)
```
