### PR TITLE
compile build.lisp after project.lisp

### DIFF
--- a/autobuild.asd
+++ b/autobuild.asd
@@ -18,9 +18,9 @@
                (:file "script")
                (:file "stage")
                (:file "synchronized-repository")
+               (:file "project")
                (:file "build")
                (:file "standard-builds")
-               (:file "project")
                (:file "autobuild"))
   :depends-on (:alexandria
                :bordeaux-threads


### PR DESCRIPTION
`DISCOVER-RECIPE` project specialization requires the project class to be
defined already

Fixes the following error:

``` lisp
; Loading "autobuild-server"

debugger invoked on a SIMPLE-ERROR in thread
#<THREAD "main thread" RUNNING {1002BDF063}>:
  There is no class named AUTOBUILD:PROJECT.

Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [TRY-RECOMPILING              ] Recompile build and try loading it again
  1: [RETRY                        ] Retry loading FASL for #<CL-SOURCE-FILE "autobuild" "build">.
  2: [ACCEPT                       ] Continue, treating loading FASL for #<CL-SOURCE-FILE "autobuild" "build"> as having been successful.
  3:                                 Retry ASDF operation.
  4: [CLEAR-CONFIGURATION-AND-RETRY] Retry ASDF operation after resetting the configuration.
  5: [ABORT                        ] Give up on "autobuild-server"
  6:                                 Exit debugger, returning to top level.

(SB-PCL::FIND-CLASS-FROM-CELL PROJECT #<SB-KERNEL::CLASSOID-CELL PROJECT> T)
0] backtrace

Backtrace for: #<SB-THREAD:THREAD "main thread" RUNNING {1002BDF063}>
0: (SB-PCL::FIND-CLASS-FROM-CELL PROJECT #<SB-KERNEL::CLASSOID-CELL PROJECT> T)
1: ((SB-C::TOP-LEVEL-FORM (LET* ((#1=#:ITEM (DEFMETHOD DISCOVER-RECIPE #2=??? #2#)) (#3=#:G841 (FDEFINITION #2#)) (#4=#:NEW842 (CONS #1# #2#)) (FUNCALL (FUNCTION (SETF SB-PCL::GENERIC-FUNCTION-INITIAL-METHODS)) #4# #3#))) #<unavailable lambda list>) [toplevel]
2: (SB-FASL::LOAD-FASL-GROUP #S(SB-FASL::FASL-INPUT :STREAM #<SB-SYS:FD-STREAM for "file /home/autobuild/.cache/common-lisp/sbcl-1.2.14.nixos-linux-x64/home/autobuild/quicklisp/local-projects/autobuild/build.fasl" {1007B58DF3}> :TABLE #(1753 SET *PACKAGE* "ORG.SHIRAKUMO.AUTOBUILD" #<PACKAGE "SB-IMPL"> SB-IMPL::%DEFVAR #<PACKAGE "AUTOBUILD"> *BUILD-OUTPUT* #1="/home/autobuild/quicklisp/local-projects/autobuild/build.lisp" #<SB-KERNEL:LAYOUT for SB-C:DEFINITION-SOURCE-LOCATION {1000044C43}> #S(SB-C:DEFINITION-SOURCE-LOCATION :NAMESTRING #1# :TOPLEVEL-FORM-NUMBER 1 :PLIST NIL) BOUNDP ...) :STACK #(0 #<FUNCTION #2=(SB-C::TOP-LEVEL-FORM (LET* (# # #) (FUNCALL # #:NEW842 #:G841))) {1007C2E55B}> #2# NIL (FUNCTION NIL (VALUES NULL &OPTIONAL)) NIL #<FDEFINITION for SB-PCL::%MAKE-METHOD-FUNCTION> #3=(:ARG-INFO (1 . T)) #<FDEFINITION for SB-PCL::METHOD-FUNCTION-FROM-FAST-FUNCTION> #<FDEFINITION for SB-MOP:SET-FUNCALLABLE-INSTANCE-FUNCTION> :FUNCTION (SB-PCL::PLIST #3# SB-PCL::METHOD-CELL (#:METHOD-CELL)) ...) :DEPRECATED-STUFF NIL :SKIP-UNTIL NIL) NIL)
3: (SB-FASL::LOAD-AS-FASL #<SB-SYS:FD-STREAM for "file /home/autobuild/.cache/common-lisp/sbcl-1.2.14.nixos-linux-x64/home/autobuild/quicklisp/local-projects/autobuild/build.fasl" {1007B58DF3}> NIL NIL)
4: ((FLET SB-FASL::LOAD-STREAM :IN LOAD) #<SB-SYS:FD-STREAM for "file /home/autobuild/.cache/common-lisp/sbcl-1.2.14.nixos-linux-x64/home/autobuild/quicklisp/local-projects/autobuild/build.fasl" {1007B58DF3}> T)
5: (LOAD #P"/home/autobuild/.cache/common-lisp/sbcl-1.2.14.nixos-linux-x64/home/autobuild/quicklisp/local-projects/autobuild/build.fasl" :VERBOSE NIL :PRINT NIL :IF-DOES-NOT-EXIST T :EXTERNAL-FORMAT :DEFAULT)
6: (UIOP/UTILITY:CALL-WITH-MUFFLED-CONDITIONS #<CLOSURE (LAMBDA NIL :IN UIOP/LISP-BUILD:LOAD*) {1007B5659B}> ("Overwriting already existing readtable ~S." #(#:FINALIZERS-OFF-WARNING :ASDF-FINALIZERS)))
7: ((SB-PCL::EMF ASDF/ACTION:PERFORM) #<unavailable argument> #<unavailable argument> #<ASDF/LISP-ACTION:LOAD-OP > #<ASDF/LISP-ACTION:CL-SOURCE-FILE "autobuild" "build">)
8: ((:METHOD ASDF/ACTION:PERFORM-WITH-RESTARTS (ASDF/LISP-ACTION:LOAD-OP ASDF/LISP-ACTION:CL-SOURCE-FILE)) #<ASDF/LISP-ACTION:LOAD-OP > #<ASDF/LISP-ACTION:CL-SOURCE-FILE "autobuild" "build">) [fast-method]
9: ((:METHOD ASDF/ACTION:PERFORM-WITH-RESTARTS :AROUND (T T)) #<ASDF/LISP-ACTION:LOAD-OP > #<ASDF/LISP-ACTION:CL-SOURCE-FILE "autobuild" "build">) [fast-method]
10: ((:METHOD ASDF/PLAN:PERFORM-PLAN (LIST)) ((#<ASDF/LISP-ACTION:PREPARE-OP > . #1=#<ASDF/SYSTEM:SYSTEM "uiop">) (#2=#<ASDF/LISP-ACTION:COMPILE-OP > . #1#) (#<ASDF/LISP-ACTION:LOAD-OP > . #1#) (#2# . #<ASDF/SYSTEM:SYSTEM "alexandria">) (#2# . #<ASDF/COMPONENT:MODULE #3="trivial-features" "src">) (#2# . #<ASDF/SYSTEM:SYSTEM #3#>) (#2# . #<ASDF/COMPONENT:MODULE #4="babel" "src">) (#2# . #<ASDF/SYSTEM:SYSTEM #4#>) (#2# . #<ASDF/COMPONENT:MODULE #5="cffi" "src">) (#2# . #<ASDF/SYSTEM:SYSTEM #5#>) (#2# . #<RADIANCE-CORE:MODULE "i-sqlite">) (#2# . #<RADIANCE-CORE:MODULE "r-simple-model">) ...) :FORCE NIL) [fast-method]
11: ((FLET SB-C::WITH-IT :IN SB-C::%WITH-COMPILATION-UNIT))
12: ((:METHOD ASDF/PLAN:PERFORM-PLAN :AROUND (T)) ((#<ASDF/LISP-ACTION:PREPARE-OP > . #1=#<ASDF/SYSTEM:SYSTEM "uiop">) (#2=#<ASDF/LISP-ACTION :COMPILE-OP > . #1#) (#<ASDF/LISP-ACTION:LOAD-OP > . #1#) (#2# . #<ASDF/SYSTEM:SYSTEM "alexandria">) (#2# . #<ASDF/COMPONENT:MODULE #3="trivial-features" "src">) (#2# . #<ASDF/SYSTEM:SYSTEM #3#>) (#2# . #<ASDF/COMPONENT:MODULE #4="babel" "src">) (#2# . #<ASDF/SYSTEM:SYSTEM #4#>) (#2# . #<ASDF/COMPONENT:MODULE #5="cffi" "src">) (#2# . #<ASDF/SYSTEM:SYSTEM #5#>) (#2# . #<RADIANCE-CORE:MODULE "i-sqlite">) (#2# . #<RADIANCE-CORE:MODULE "r-simple-model">) ...) :VERBOSE NIL) [fast-method]
13: ((FLET SB-C::WITH-IT :IN SB-C::%WITH-COMPILATION-UNIT))
14: ((:METHOD ASDF/PLAN:PERFORM-PLAN :AROUND (T)) #<ASDF/PLAN:SEQUENTIAL-PLAN {10039AB573}> :VERBOSE NIL) [fast-method]
15: ((:METHOD ASDF/OPERATE:OPERATE (ASDF/OPERATION:OPERATION ASDF/COMPONENT:COMPONENT)) #<ASDF/LISP-ACTION:LOAD-OP :VERBOSE NIL> #<RADIANCE-CORE:MODULE "autobuild-server"> :VERBOSE NIL) [fast-method]
16: ((SB-PCL::EMF ASDF/OPERATE:OPERATE) #<unused argument> #<unused argument> #<ASDF/LISP-ACTION:LOAD-OP :VERBOSE NIL> #<RADIANCE-CORE:MODULE "autobuild-server"> :VERBOSE NIL)
17: ((LAMBDA NIL :IN ASDF/OPERATE:OPERATE))
18: ((:METHOD ASDF/OPERATE:OPERATE :AROUND (T T)) #<ASDF/LISP-ACTION:LOAD-OP :VERBOSE NIL> #<RADIANCE-CORE:MODULE "autobuild-server"> :VERBOSE NIL) [fast-method]
19: ((:METHOD ASDF/OPERATE:OPERATE :AROUND (ASDF/LISP-ACTION:LOAD-OP MODULARIZE:MODULE)) #<ASDF/LISP-ACTION:LOAD-OP :VERBOSE NIL> #<RADIANCE-CORE:MODULE "autobuild-server"> :VERBOSE NIL) [fast-method]
20: ((SB-PCL::EMF ASDF/OPERATE:OPERATE) #<unused argument> #<unused argument> ASDF/LISP-ACTION:LOAD-OP "autobuild-server" :VERBOSE NIL)
21: ((LAMBDA NIL :IN ASDF/OPERATE:OPERATE))
22: (ASDF/CACHE:CALL-WITH-ASDF-CACHE #<CLOSURE (LAMBDA NIL :IN ASDF/OPERATE:OPERATE) {100399EF7B}> :OVERRIDE NIL :KEY NIL)
23: ((:METHOD ASDF/OPERATE:OPERATE :AROUND (T T)) ASDF/LISP-ACTION:LOAD-OP "autobuild-server" :VERBOSE NIL) [fast-method]
24: ((:METHOD ASDF/OPERATE:OPERATE :AROUND (T T)) ASDF/LISP-ACTION:LOAD-OP "autobuild-server" :VERBOSE NIL) [fast-method]
25: (QUICKLISP-CLIENT::CALL-WITH-MACROEXPAND-PROGRESS #<CLOSURE (LAMBDA NIL :IN QUICKLISP-CLIENT::APPLY-LOAD-STRATEGY) {1003987F4B}>)
26: (QUICKLISP-CLIENT::AUTOLOAD-SYSTEM-AND-DEPENDENCIES "autobuild-server" :PROMPT NIL)
27: ((:METHOD QL-IMPL-UTIL::%CALL-WITH-QUIET-COMPILATION (T T)) #<unavailable argument> #<CLOSURE (FLET QUICKLISP-CLIENT::QL :IN QUICKLISP-CLIENT:QUICKLOAD) {10038DE2DB}>) [fast-method]
28: ((:METHOD QL-IMPL-UTIL::%CALL-WITH-QUIET-COMPILATION :AROUND (QL-IMPL:SBCL T)) #<QL-IMPL:SBCL {1003E28D13}> #<CLOSURE (FLET QUICKLISP-CLIENT::QL :IN QUICKLISP-CLIENT:QUICKLOAD) {10038DE2DB}>) [fast-method]
29: ((:METHOD QUICKLISP-CLIENT:QUICKLOAD (T)) #<unavailable argument> :PROMPT NIL :SILENT NIL :VERBOSE NIL) [fast-method]
30: (QL-DIST::CALL-WITH-CONSISTENT-DISTS #<CLOSURE (LAMBDA NIL :IN QUICKLISP-CLIENT:QUICKLOAD) {10038C883B}>)
31: (SB-INT:SIMPLE-EVAL-IN-LEXENV (QUICKLISP-CLIENT:QUICKLOAD :AUTOBUILD-SERVER) #<NULL-LEXENV>)
32: (EVAL (QUICKLISP-CLIENT:QUICKLOAD :AUTOBUILD-SERVER))
33: (SB-EXT:INTERACTIVE-EVAL (QUICKLISP-CLIENT:QUICKLOAD :AUTOBUILD-SERVER) :EVAL NIL)
34: (SB-IMPL::REPL-FUN NIL)
35: ((LAMBDA NIL :IN SB-IMPL::TOPLEVEL-REPL))
36: (SB-IMPL::%WITH-REBOUND-IO-SYNTAX #<CLOSURE (LAMBDA NIL :IN SB-IMPL::TOPLEVEL-REPL) {1003593EBB}>)
37: (SB-IMPL::TOPLEVEL-REPL NIL)
38: (SB-IMPL::TOPLEVEL-INIT)
39: ((FLET #:WITHOUT-INTERRUPTS-BODY-83 :IN SB-EXT:SAVE-LISP-AND-DIE))
40: ((LABELS SB-IMPL::RESTART-LISP :IN SB-EXT:SAVE-LISP-AND-DIE))
```
